### PR TITLE
Add possibility to build against system SWORD library

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -45,7 +45,7 @@
             ["OS=='linux'", {
                 'include_dirs': [
                     "<!@(node -p \"require('node-addon-api').include\")",
-                    "sword/include"
+                    "<!@(./scripts/get_sword_include_path.sh)"
                 ],
                 "libraries": [
                     '<!@(./scripts/get_sword_library.sh \"../sword_build/libsword.a\")',
@@ -60,7 +60,7 @@
             ["OS=='mac'", {
                 'include_dirs': [
                     "<!@(node -p \"require('node-addon-api').include\")",
-                    "sword/include"
+                    "<!@(./scripts/get_sword_include_path.sh)"
                 ],
                 "libraries": [
                     '<(module_root_dir)/sword_build/libsword.a',

--- a/binding.gyp
+++ b/binding.gyp
@@ -48,7 +48,7 @@
                     "sword/include"
                 ],
                 "libraries": [
-                    '<(module_root_dir)/sword_build/libsword.a',
+                    '<!@(./scripts/get_sword_library.sh \"../sword_build/libsword.a\")',
                     '<!@(pkg-config --libs libcurl)',
                     '<!@(pkg-config --libs icu-uc icu-io)'
                 ],

--- a/scripts/build_sword.sh
+++ b/scripts/build_sword.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+if [ "$LINK_SYSTEM_SWORD" = "1" ]; then
+    echo "Linking system SWORD library!"
+    exit 0
+else
+    echo "Linking self-compiled SWORD library"
+fi
+
 # CHECKOUT
 git clone https://github.com/bibletime/crosswire-sword-mirror sword
 git -C sword checkout e34fd3

--- a/scripts/build_sword.sh
+++ b/scripts/build_sword.sh
@@ -2,7 +2,7 @@
 
 # CHECKOUT
 git clone https://github.com/bibletime/crosswire-sword-mirror sword
-#git -C sword checkout tags/sword-1-8-1
+git -C sword checkout e34fd3
 
 # PATCHES
 case "$(uname -s)" in

--- a/scripts/get_sword_include_path.sh
+++ b/scripts/get_sword_include_path.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# This script is used by binding.gyp to dynamically determine the include path of the SWORD library.
+# It returns the system include path of the SWORD library if the environment variable
+# LINK_SYSTEM_SWORD has the value 1 or otherwise the path to the locally cloned sword/include directory.
 
 if [ "$LINK_SYSTEM_SWORD" = "1" ]; then
     echo "/usr/include/sword"

--- a/scripts/get_sword_include_path.sh
+++ b/scripts/get_sword_include_path.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$LINK_SYSTEM_SWORD" = "1" ]; then
+    echo "/usr/include/sword"
+else
+    echo "sword/include"
+fi

--- a/scripts/get_sword_include_path.sh
+++ b/scripts/get_sword_include_path.sh
@@ -4,7 +4,8 @@
 # LINK_SYSTEM_SWORD has the value 1 or otherwise the path to the locally cloned sword/include directory.
 
 if [ "$LINK_SYSTEM_SWORD" = "1" ]; then
-    echo "/usr/include/sword"
+    # This command turns something like -I/usr/include/sword into /usr/include/sword (it cuts out all character from the 3rd one)
+    pkg-config --cflags sword | cut -c3-
 else
     echo "sword/include"
 fi

--- a/scripts/get_sword_library.sh
+++ b/scripts/get_sword_library.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$LINK_SYSTEM_SWORD" = "1" ]; then
+    pkg-config --libs sword
+else
+    echo $1
+fi


### PR DESCRIPTION
With these changes it's now possible to build against the system SWORD library by defining the environment variable `LINK_SYSTEM_SWORD=1` before calling `npm install`.